### PR TITLE
Delegate Withdrawal Wallet Smart Contract (Clarity)

### DIFF
--- a/lamp_contract/Clarinet.toml
+++ b/lamp_contract/Clarinet.toml
@@ -5,6 +5,11 @@ authors = []
 telemetry = true
 cache_dir = '.\.cache'
 requirements = []
+[contracts.delegate_withdrawal_wallet]
+path = 'contracts/delegate_withdrawal_wallet.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.file_backup]
 path = 'contracts/file_backup.clar'
 clarity_version = 2

--- a/lamp_contract/contracts/delegate_withdrawal_wallet.clar
+++ b/lamp_contract/contracts/delegate_withdrawal_wallet.clar
@@ -1,0 +1,167 @@
+;; Delegate Withdrawal Wallet Contract
+;; Allows users to delegate withdrawal rights to other addresses with limits
+
+;; Error constants
+(define-constant err-owner-only (err u100))
+(define-constant err-not-authorized (err u101))
+(define-constant err-insufficient-balance (err u102))
+(define-constant err-limit-exceeded (err u103))
+(define-constant err-invalid-amount (err u104))
+(define-constant err-delegate-not-found (err u105))
+
+;; Data variables
+(define-data-var contract-owner principal tx-sender)
+
+;; Data maps
+;; Map to store user balances
+(define-map user-balances principal uint)
+
+;; Map to store delegation information
+;; Key: {owner: principal, delegate: principal}
+;; Value: {limit: uint, used: uint}
+(define-map delegations 
+    {owner: principal, delegate: principal}
+    {limit: uint, used: uint})
+
+;; Map to track all delegates for an owner (for enumeration)
+(define-map owner-delegates principal (list 10 principal))
+
+;; Read-only functions
+
+;; Get user balance
+(define-read-only (get-balance (user principal))
+    (default-to u0 (map-get? user-balances user)))
+
+;; Get delegation info
+(define-read-only (get-delegation (owner principal) (delegate principal))
+    (map-get? delegations {owner: owner, delegate: delegate}))
+
+;; Get remaining delegation limit
+(define-read-only (get-remaining-limit (owner principal) (delegate principal))
+    (match (map-get? delegations {owner: owner, delegate: delegate})
+        delegation (- (get limit delegation) (get used delegation))
+        u0))
+
+;; Get all delegates for an owner
+(define-read-only (get-delegates (owner principal))
+    (default-to (list) (map-get? owner-delegates owner)))
+
+;; Check if address is authorized to withdraw
+(define-read-only (is-authorized (owner principal) (delegate principal) (amount uint))
+    (if (is-eq owner delegate)
+        true
+        (match (map-get? delegations {owner: owner, delegate: delegate})
+            delegation (<= (+ (get used delegation) amount) (get limit delegation))
+            false)))
+
+;; Public functions
+
+;; Deposit funds to the contract
+(define-public (deposit (amount uint))
+    (begin
+        (asserts! (> amount u0) err-invalid-amount)
+        (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+        (map-set user-balances tx-sender 
+            (+ (get-balance tx-sender) amount))
+        (ok true)))
+
+;; Add or update a delegate
+(define-public (set-delegate (delegate principal) (limit uint))
+    (let ((current-delegates (get-delegates tx-sender)))
+        (begin
+            (asserts! (not (is-eq tx-sender delegate)) err-not-authorized)
+            (asserts! (> limit u0) err-invalid-amount)
+            
+            ;; Add delegate to owner's delegate list if not already present
+            (if (is-none (index-of current-delegates delegate))
+                (map-set owner-delegates tx-sender 
+                    (unwrap! (as-max-len? (append current-delegates delegate) u10) 
+                        err-not-authorized))
+                true)
+            
+            ;; Set or update delegation
+            (map-set delegations 
+                {owner: tx-sender, delegate: delegate}
+                {limit: limit, used: u0})
+            (ok true))))
+
+;; Remove a delegate
+(define-public (remove-delegate (delegate principal))
+    (let ((current-delegates (get-delegates tx-sender)))
+        (begin
+            (asserts! (is-some (index-of current-delegates delegate)) err-delegate-not-found)
+            
+            ;; Remove from delegations map
+            (map-delete delegations {owner: tx-sender, delegate: delegate})
+            
+            ;; Remove from owner's delegate list
+            (map-set owner-delegates tx-sender 
+                (filter is-not-delegate current-delegates))
+            (ok true))))
+
+;; Helper function for filtering delegates
+(define-private (is-not-delegate (potential-delegate principal))
+    (not (is-eq potential-delegate tx-sender)))
+
+;; Withdraw funds (can be called by owner or authorized delegate)
+(define-public (withdraw (owner principal) (amount uint))
+    (let (
+        (owner-balance (get-balance owner))
+        (delegation-info (get-delegation owner tx-sender))
+    )
+        (begin
+            (asserts! (> amount u0) err-invalid-amount)
+            (asserts! (>= owner-balance amount) err-insufficient-balance)
+            
+            ;; Check authorization
+            (if (is-eq owner tx-sender)
+                ;; Owner can withdraw any amount up to their balance
+                true
+                ;; Delegate must be authorized and within limits
+                (begin
+                    (asserts! (is-some delegation-info) err-not-authorized)
+                    (let ((delegation (unwrap-panic delegation-info)))
+                        (asserts! (<= (+ (get used delegation) amount) (get limit delegation)) 
+                            err-limit-exceeded)
+                        ;; Update used amount for delegate
+                        (map-set delegations 
+                            {owner: owner, delegate: tx-sender}
+                            {limit: (get limit delegation), 
+                             used: (+ (get used delegation) amount)}))))
+            
+            ;; Update owner balance
+            (map-set user-balances owner (- owner-balance amount))
+            
+            ;; Transfer STX to the caller
+            (try! (as-contract (stx-transfer? amount tx-sender tx-sender)))
+            (ok true))))
+
+;; Reset delegate usage (only owner can call this)
+(define-public (reset-delegate-usage (delegate principal))
+    (match (get-delegation tx-sender delegate)
+        delegation 
+            (begin
+                (map-set delegations 
+                    {owner: tx-sender, delegate: delegate}
+                    {limit: (get limit delegation), used: u0})
+                (ok true))
+        err-delegate-not-found))
+
+;; Emergency withdraw (only owner can withdraw all their funds)
+(define-public (emergency-withdraw)
+    (let ((balance (get-balance tx-sender)))
+        (begin
+            (asserts! (> balance u0) err-insufficient-balance)
+            (map-set user-balances tx-sender u0)
+            (try! (as-contract (stx-transfer? balance tx-sender tx-sender)))
+            (ok true))))
+
+;; Contract management functions (for contract owner)
+(define-public (set-contract-owner (new-owner principal))
+    (begin
+        (asserts! (is-eq tx-sender (var-get contract-owner)) err-owner-only)
+        (var-set contract-owner new-owner)
+        (ok true)))
+
+(define-read-only (get-contract-owner)
+    (var-get contract-owner))

--- a/lamp_contract/tests/delegate_withdrawal_wallet.test.ts
+++ b/lamp_contract/tests/delegate_withdrawal_wallet.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
# Delegate Withdrawal Wallet Smart Contract

## Overview

The **Delegate Withdrawal Wallet Smart Contract** allows users to securely manage their STX funds while delegating withdrawal rights to trusted third parties (delegates). Each delegate can be assigned a specific withdrawal limit, ensuring that owners retain full control while enabling flexible fund access.

This contract supports deposits, withdrawals (by owners or delegates), delegation management, limit tracking, emergency withdrawals, and owner-level administrative functions.

---

## Features

* **Deposits:** Users can deposit STX into their account balance.
* **Delegated Withdrawals:** Owners can grant delegates withdrawal rights with predefined limits.
* **Authorization Control:** Withdrawals require either direct ownership or a valid delegation with available limit.
* **Delegate Management:** Add, update, or remove delegates with customizable withdrawal limits.
* **Usage Tracking:** Each delegate’s withdrawals are tracked to prevent exceeding assigned limits.
* **Limit Reset:** Owners can reset delegate usage counters.
* **Emergency Withdrawals:** Owners can withdraw all their funds instantly.
* **Ownership Management:** Contract ownership can be transferred securely.

---

## Error Codes

* `u100` → **err-owner-only**: Action restricted to contract owner.
* `u101` → **err-not-authorized**: Unauthorized withdrawal attempt.
* `u102` → **err-insufficient-balance**: Insufficient funds for operation.
* `u103` → **err-limit-exceeded**: Delegate has exceeded their withdrawal limit.
* `u104` → **err-invalid-amount**: Invalid amount (must be > 0).
* `u105` → **err-delegate-not-found**: Delegate does not exist in delegation records.

---

## Data Structures

* **`user-balances` (map)** → Tracks each user’s balance.
* **`delegations` (map)** → Stores delegate info `{limit, used}` for `{owner, delegate}` pairs.
* **`owner-delegates` (map)** → Maintains a list of delegates per owner (max 10).
* **`contract-owner` (var)** → Stores the principal of the contract owner.

---

## Public Functions

### Core Operations

* `deposit (amount uint)` → Deposit STX into caller’s balance.
* `withdraw (owner principal) (amount uint)` → Withdraw funds (owner or delegate).
* `emergency-withdraw` → Owner withdraws all their funds.

### Delegate Management

* `set-delegate (delegate principal) (limit uint)` → Add or update a delegate with a withdrawal limit.
* `remove-delegate (delegate principal)` → Remove an existing delegate.
* `reset-delegate-usage (delegate principal)` → Reset delegate’s used withdrawal amount.

### Contract Management

* `set-contract-owner (new-owner principal)` → Transfer contract ownership.
* `get-contract-owner` → Returns the current contract owner.

---

## Read-Only Functions

* `get-balance (user principal)` → Returns user’s current balance.
* `get-delegation (owner principal) (delegate principal)` → Returns delegation info for a delegate.
* `get-remaining-limit (owner principal) (delegate principal)` → Returns unused limit for a delegate.
* `get-delegates (owner principal)` → Lists all delegates assigned by an owner.
* `is-authorized (owner principal) (delegate principal) (amount uint)` → Checks if a delegate is authorized for a withdrawal of `amount`.

---

## Security Considerations

* Delegation limits must be carefully set to prevent abuse.
* Only the owner can reset delegate usage or perform emergency withdrawals.
* Delegates cannot remove or overwrite other delegates.
* Contract owner controls upgrade/administrative rights.

---

## Example Use Case

1. Alice deposits **100 STX** into her wallet.
2. Alice sets Bob as a delegate with a **30 STX limit**.
3. Bob withdraws **10 STX** on Alice’s behalf.
4. Alice checks Bob’s remaining limit (**20 STX**).
5. Alice resets Bob’s usage, restoring his full **30 STX limit**.
6. In an emergency, Alice calls `emergency-withdraw` to withdraw her full balance.

---

## License

This contract is released under the **MIT License**.
