### PR TITLE
Fee Distribution with Multi-Send Smart Contract (STX)

### DIFF
--- a/lamp_contract/Clarinet.toml
+++ b/lamp_contract/Clarinet.toml
@@ -10,6 +10,11 @@ path = 'contracts/delegate_withdrawal_wallet.clar'
 clarity_version = 2
 epoch = 2.5
 
+[contracts.fee_distribution]
+path = 'contracts/fee_distribution.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.file_backup]
 path = 'contracts/file_backup.clar'
 clarity_version = 2

--- a/lamp_contract/contracts/fee_distribution.clar
+++ b/lamp_contract/contracts/fee_distribution.clar
@@ -1,0 +1,176 @@
+;; Multi-Send with Fee Distribution Contract
+;; Allows users to send STX to multiple recipients while collecting platform fees
+
+;; Constants
+(define-constant CONTRACT_OWNER tx-sender)
+(define-constant ERR_UNAUTHORIZED (err u100))
+(define-constant ERR_INSUFFICIENT_BALANCE (err u101))
+(define-constant ERR_INVALID_AMOUNT (err u102))
+(define-constant ERR_EMPTY_RECIPIENTS (err u103))
+(define-constant ERR_TRANSFER_FAILED (err u104))
+(define-constant ERR_INVALID_FEE_RATE (err u105))
+
+;; Data Variables
+(define-data-var fee-rate uint u250) ;; Fee rate in basis points (250 = 2.5%)
+(define-data-var accumulated-fees uint u0)
+(define-data-var total-volume uint u0)
+
+;; Data Maps
+(define-map authorized-owners principal bool)
+(define-map owner-fee-shares principal uint) ;; Share percentages in basis points
+(define-map withdrawal-history principal uint)
+
+;; Initialize contract owner
+(map-set authorized-owners CONTRACT_OWNER true)
+(map-set owner-fee-shares CONTRACT_OWNER u10000) ;; 100% initially
+
+;; Read-only functions
+(define-read-only (get-fee-rate)
+  (var-get fee-rate)
+)
+
+(define-read-only (get-accumulated-fees)
+  (var-get accumulated-fees)
+)
+
+(define-read-only (get-total-volume)
+  (var-get total-volume)
+)
+
+(define-read-only (is-authorized-owner (owner principal))
+  (default-to false (map-get? authorized-owners owner))
+)
+
+(define-read-only (get-owner-fee-share (owner principal))
+  (default-to u0 (map-get? owner-fee-shares owner))
+)
+
+(define-read-only (get-withdrawal-history (owner principal))
+  (default-to u0 (map-get? withdrawal-history owner))
+)
+
+(define-read-only (calculate-fee (amount uint))
+  (/ (* amount (var-get fee-rate)) u10000)
+)
+
+(define-read-only (calculate-owner-fee-amount (owner principal))
+  (let ((share (get-owner-fee-share owner))
+        (total-fees (var-get accumulated-fees)))
+    (/ (* total-fees share) u10000))
+)
+
+;; Private functions
+(define-private (send-stx-to-recipient (recipient {address: principal, amount: uint}))
+  (let ((address (get address recipient))
+        (amount (get amount recipient)))
+    (if (> amount u0)
+      (stx-transfer? amount tx-sender address)
+      (ok true)))
+)
+
+(define-private (sum-amounts (recipient {address: principal, amount: uint}) (sum uint))
+  (+ sum (get amount recipient))
+)
+
+;; Public functions
+
+;; Add or update authorized owner with fee share
+(define-public (add-owner (new-owner principal) (fee-share uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (asserts! (<= fee-share u10000) ERR_INVALID_FEE_RATE)
+    (map-set authorized-owners new-owner true)
+    (map-set owner-fee-shares new-owner fee-share)
+    (ok true))
+)
+
+;; Remove authorized owner
+(define-public (remove-owner (owner principal))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (asserts! (not (is-eq owner CONTRACT_OWNER)) ERR_UNAUTHORIZED)
+    (map-delete authorized-owners owner)
+    (map-delete owner-fee-shares owner)
+    (ok true))
+)
+
+;; Update fee rate (only contract owner)
+(define-public (set-fee-rate (new-rate uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (asserts! (<= new-rate u1000) ERR_INVALID_FEE_RATE) ;; Max 10%
+    (var-set fee-rate new-rate)
+    (ok true))
+)
+
+;; Multi-send function with fee collection
+(define-public (multi-send (recipients (list 50 {address: principal, amount: uint})))
+  (let ((total-amount (fold sum-amounts recipients u0))
+        (fee-amount (calculate-fee total-amount))
+        (total-required (+ total-amount fee-amount)))
+    (begin
+      ;; Validation checks
+      (asserts! (> (len recipients) u0) ERR_EMPTY_RECIPIENTS)
+      (asserts! (> total-amount u0) ERR_INVALID_AMOUNT)
+      (asserts! (>= (stx-get-balance tx-sender) total-required) ERR_INSUFFICIENT_BALANCE)
+      
+      ;; Process all transfers
+      (let ((transfer-results (map send-stx-to-recipient recipients)))
+        (begin
+          ;; Update contract state
+          (var-set accumulated-fees (+ (var-get accumulated-fees) fee-amount))
+          (var-set total-volume (+ (var-get total-volume) total-amount))
+          
+          ;; Transfer fee to contract
+          (if (> fee-amount u0)
+            (match (stx-transfer? fee-amount tx-sender (as-contract tx-sender))
+              success-fee (ok {
+                total-sent: total-amount,
+                fee-collected: fee-amount,
+                recipients-count: (len recipients)
+              })
+              error-fee ERR_TRANSFER_FAILED)
+            (ok {
+              total-sent: total-amount,
+              fee-collected: fee-amount,
+              recipients-count: (len recipients)
+            }))))))
+)
+
+;; Withdraw accumulated fees (for authorized owners)
+(define-public (withdraw-fees)
+  (let ((caller tx-sender)
+        (owner-fee-amount (calculate-owner-fee-amount caller)))
+    (begin
+      (asserts! (is-authorized-owner caller) ERR_UNAUTHORIZED)
+      (asserts! (> owner-fee-amount u0) ERR_INSUFFICIENT_BALANCE)
+      
+      ;; Transfer fees to owner
+      (match (as-contract (stx-transfer? owner-fee-amount tx-sender caller))
+        success (begin
+          ;; Update withdrawal history
+          (map-set withdrawal-history caller 
+            (+ (get-withdrawal-history caller) owner-fee-amount))
+          ;; Reduce accumulated fees
+          (var-set accumulated-fees (- (var-get accumulated-fees) owner-fee-amount))
+          (ok owner-fee-amount))
+        error ERR_TRANSFER_FAILED)))
+)
+
+;; Emergency withdraw (only contract owner)
+(define-public (emergency-withdraw (amount uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (asserts! (<= amount (stx-get-balance (as-contract tx-sender))) ERR_INSUFFICIENT_BALANCE)
+    (as-contract (stx-transfer? amount tx-sender CONTRACT_OWNER)))
+)
+
+;; Private function to process a single batch
+(define-private (process-single-batch (recipients (list 50 {address: principal, amount: uint})))
+  (multi-send recipients)
+)
+
+;; Batch multi-send for efficiency
+(define-public (batch-multi-send (batch-recipients (list 10 (list 50 {address: principal, amount: uint}))))
+  (ok (map process-single-batch batch-recipients))
+)

--- a/lamp_contract/tests/fee_distribution.test.ts
+++ b/lamp_contract/tests/fee_distribution.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body>
<hr>
<h1>Multi-Send with Fee Distribution Contract</h1>
<p>A <strong>Clarity smart contract</strong> that enables <strong>batch STX transfers</strong> with built-in <strong>platform fee collection and distribution</strong>.<br>
The contract supports <strong>multi-recipient transfers</strong>, <strong>fee sharing among multiple owners</strong>, and <strong>secure fee withdrawal</strong>.</p>
<hr>
<h2>✨ Features</h2>
<ul>
<li>
<p><strong>Multi-Send Transfers</strong> – Send STX to up to 50 recipients in a single transaction.</p>
</li>
<li>
<p><strong>Platform Fee Collection</strong> – A configurable fee (default: 2.5%) is applied on each batch.</p>
</li>
<li>
<p><strong>Fee Distribution</strong> – Multiple authorized owners can receive shares of collected fees.</p>
</li>
<li>
<p><strong>Batch Processing</strong> – Supports nested batch transfers (up to 10 batches of 50 recipients each).</p>
</li>
<li>
<p><strong>Withdrawal System</strong> – Owners can withdraw their proportional fee shares anytime.</p>
</li>
<li>
<p><strong>Emergency Controls</strong> – Contract owner can withdraw funds in emergencies.</p>
</li>
<li>
<p><strong>Transparent Tracking</strong> – Maintains records of fee rate, total fees, total transaction volume, and withdrawal history.</p>
</li>
</ul>
<hr>
<h2>📜 Error Codes</h2>

Code | Meaning
-- | --
u100 | Unauthorized action
u101 | Insufficient balance
u102 | Invalid transfer amount
u103 | Empty recipients list
u104 | Transfer failed
u105 | Invalid fee rate


<hr>
<h2>⚙️ Public Functions</h2>
<h3><code inline="">add-owner (new-owner principal) (fee-share uint)</code></h3>
<p>Add or update an authorized fee owner with a share percentage.</p>
<ul>
<li>
<p>Only callable by contract owner.</p>
</li>
<li>
<p><code inline="">fee-share</code> is in basis points (1% = 100, 100% = 10,000).</p>
</li>
</ul>
<hr>
<h3><code inline="">remove-owner (owner principal)</code></h3>
<p>Removes an authorized owner.</p>
<ul>
<li>
<p>Cannot remove the <strong>contract owner</strong>.</p>
</li>
</ul>
<hr>
<h3><code inline="">set-fee-rate (new-rate uint)</code></h3>
<p>Update the platform fee rate.</p>
<ul>
<li>
<p>Maximum allowed: <strong>10% (1000 basis points)</strong>.</p>
</li>
<li>
<p>Only callable by contract owner.</p>
</li>
</ul>
<hr>
<h3><code inline="">multi-send (recipients (list 50 {address: principal, amount: uint}))</code></h3>
<p>Execute a batch STX transfer with fee deduction.</p>
<ul>
<li>
<p>Automatically deducts fees and updates contract state.</p>
</li>
<li>
<p>Returns:</p>
<pre><code class="language-clarity">{
  total-sent: uint,
  fee-collected: uint,
  recipients-count: uint
}
</code></pre>
</li>
</ul>
<hr>
<h3><code inline="">withdraw-fees</code></h3>
<p>Authorized owners withdraw their proportional share of accumulated fees.</p>
<ul>
<li>
<p>Updates <strong>withdrawal-history</strong>.</p>
</li>
<li>
<p>Deducts withdrawn amount from <strong>accumulated-fees</strong>.</p>
</li>
</ul>
<hr>
<h3><code inline="">emergency-withdraw (amount uint)</code></h3>
<p>Emergency fund withdrawal by contract owner.</p>
<ul>
<li>
<p>Ensures amount ≤ contract balance.</p>
</li>
</ul>
<hr>
<h3><code inline="">batch-multi-send (batch-recipients (list 10 (list 50 {address: principal, amount: uint})))</code></h3>
<p>Process multiple multi-send batches in a single call for efficiency.</p>
<hr>
<h2>🔍 Read-Only Functions</h2>
<ul>
<li>
<p><strong><code inline="">get-fee-rate</code></strong> – Returns the current fee rate.</p>
</li>
<li>
<p><strong><code inline="">get-accumulated-fees</code></strong> – Returns total unclaimed fees.</p>
</li>
<li>
<p><strong><code inline="">get-total-volume</code></strong> – Returns total STX transferred through contract.</p>
</li>
<li>
<p><strong><code inline="">is-authorized-owner (owner)</code></strong> – Checks if a principal is an authorized fee owner.</p>
</li>
<li>
<p><strong><code inline="">get-owner-fee-share (owner)</code></strong> – Returns fee share percentage for an owner.</p>
</li>
<li>
<p><strong><code inline="">get-withdrawal-history (owner)</code></strong> – Returns cumulative fees withdrawn by an owner.</p>
</li>
<li>
<p><strong><code inline="">calculate-fee (amount)</code></strong> – Calculates fee for a given transfer amount.</p>
</li>
<li>
<p><strong><code inline="">calculate-owner-fee-amount (owner)</code></strong> – Calculates current claimable fee share for an owner.</p>
</li>
</ul>
<hr>
<h2>📊 State &amp; Data Structures</h2>
<ul>
<li>
<p><strong><code inline="">fee-rate</code> (var)</strong> – Fee percentage in basis points (default: 250 = 2.5%).</p>
</li>
<li>
<p><strong><code inline="">accumulated-fees</code> (var)</strong> – Total platform fees collected.</p>
</li>
<li>
<p><strong><code inline="">total-volume</code> (var)</strong> – Total STX transferred.</p>
</li>
<li>
<p><strong><code inline="">authorized-owners</code> (map)</strong> – Mapping of owners → <code inline="">true/false</code>.</p>
</li>
<li>
<p><strong><code inline="">owner-fee-shares</code> (map)</strong> – Mapping of owners → fee share (basis points).</p>
</li>
<li>
<p><strong><code inline="">withdrawal-history</code> (map)</strong> – Mapping of owners → total withdrawn.</p>
</li>
</ul>
<hr>
<h2>🚀 Example Usage</h2>
<pre><code class="language-clarity">;; Alice sends 1,000,000 µSTX (1 STX) split across 2 recipients
(contract-call? .multi-send-with-fee multi-send
  (list
    { address: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM, amount: u500000 }
    { address: 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG, amount: u500000 }
  )
)

;; Contract deducts 2.5% fee = 25,000 µSTX
;; Total required = 1,025,000 µSTX
;; Each recipient receives 500,000 µSTX, fee stored in accumulated-fees
</code></pre>
<hr>
<h2>📄 License</h2>
<p>This project is licensed under the MIT License:</p>
<pre><code>MIT License

Copyright (c) EJEMBA

Permission is hereby granted, free of charge, to any person obtaining a copy
...
</code></pre>
<hr>
</body></html><!--EndFragment-->
</body>
</html>